### PR TITLE
read-arg function which defaults to symbol at point

### DIFF
--- a/replace-symbol.el
+++ b/replace-symbol.el
@@ -51,7 +51,7 @@ Returns when a scan-error is caught."
 ;; Dynamic variable used for recursive calls to replace-symbol-in-sexp
 (defvar replace-symbol--replaced-in-sexp 0)
 
-(defun replace--symbol-read-args ()
+(defun replace-symbol--read-args ()
   (let* ((sap (symbol-at-point))
          (def (when (and sap (symbolp sap))
                 (symbol-name sap)))
@@ -68,7 +68,7 @@ Returns when a scan-error is caught."
   "Replace the symbol FROM with TO in the sexp following the point.
 If RECURSIVE is true, do not announce the number of replacements."
   ;; (interactive "sReplace symbol: \nsReplace symbol %s with: ")
-  (interactive (append (replace-symbol-read-args)
+  (interactive (append (replace-symbol--read-args)
                        (list current-prefix-arg)))
   (let ((do-replace
          (lambda ()
@@ -108,7 +108,7 @@ If RECURSIVE is true, do not announce the number of replacements."
 ;;;###autoload
 (defun replace-symbol-in-buffer (from to)
   "Replace the symbol FROM with TO in the entire buffer."
-  (interactive (replace-symbol-read-args))
+  (interactive (replace-symbol--read-args))
   (let ((replace-symbol--replaced-in-sexp 0))
     (save-excursion
       (goto-char (point-min))

--- a/replace-symbol.el
+++ b/replace-symbol.el
@@ -49,13 +49,27 @@ Returns when a scan-error is caught."
       (scan-error nil))))
 
 ;; Dynamic variable used for recursive calls to replace-symbol-in-sexp
-(defvar replace-symbol--replaced-in-sexp nil)
+(defvar replace-symbol--replaced-in-sexp 0)
+
+(defun replace-symbol-read-args ()
+  (let* ((sap (symbol-at-point))
+         (def (when (and sap (symbolp sap))
+                (symbol-name sap)))
+         (from (read-string (if def
+                                (format "Replace symbol (default %s): " def)
+                              "Replace symbol: ")
+                            nil query-replace-from-history-variable def))
+         (to (read-string (format "Replace symbol %s with: " from)
+                          nil query-replace-to-history-variable nil)))
+    (list from to)))
 
 ;;;###autoload
 (defun replace-symbol-in-sexp (from to &optional recursive)
   "Replace the symbol FROM with TO in the sexp following the point.
 If RECURSIVE is true, do not announce the number of replacements."
-  (interactive "sReplace symbol: \nsReplace symbol %s with: ")
+  ;; (interactive "sReplace symbol: \nsReplace symbol %s with: ")
+  (interactive (append (replace-symbol-read-args)
+                       (list current-prefix-arg)))
   (let ((do-replace
          (lambda ()
            (save-excursion
@@ -94,7 +108,7 @@ If RECURSIVE is true, do not announce the number of replacements."
 ;;;###autoload
 (defun replace-symbol-in-buffer (from to)
   "Replace the symbol FROM with TO in the entire buffer."
-  (interactive "sReplace symbol: \nsReplace symbol %s with: ")
+  (interactive (replace-symbol-read-args))
   (let ((replace-symbol--replaced-in-sexp 0))
     (save-excursion
       (goto-char (point-min))

--- a/replace-symbol.el
+++ b/replace-symbol.el
@@ -51,7 +51,7 @@ Returns when a scan-error is caught."
 ;; Dynamic variable used for recursive calls to replace-symbol-in-sexp
 (defvar replace-symbol--replaced-in-sexp 0)
 
-(defun replace-symbol-read-args ()
+(defun replace--symbol-read-args ()
   (let* ((sap (symbol-at-point))
          (def (when (and sap (symbolp sap))
                 (symbol-name sap)))

--- a/replace-symbol.el
+++ b/replace-symbol.el
@@ -52,6 +52,7 @@ Returns when a scan-error is caught."
 (defvar replace-symbol--replaced-in-sexp 0)
 
 (defun replace-symbol--read-args ()
+  "Query from/to replace strings, defaulting to symbol at point."
   (let* ((sap (symbol-at-point))
          (def (when (and sap (symbolp sap))
                 (symbol-name sap)))
@@ -67,9 +68,7 @@ Returns when a scan-error is caught."
 (defun replace-symbol-in-sexp (from to &optional recursive)
   "Replace the symbol FROM with TO in the sexp following the point.
 If RECURSIVE is true, do not announce the number of replacements."
-  ;; (interactive "sReplace symbol: \nsReplace symbol %s with: ")
-  (interactive (append (replace-symbol--read-args)
-                       (list current-prefix-arg)))
+  (interactive (replace-symbol--read-args))
   (let ((do-replace
          (lambda ()
            (save-excursion


### PR DESCRIPTION
I find I typically want to replace the symbol my cursor is at. 

(I didn't get what "recursive" was good for, but I changed the default to 0 since otherwise it gave an error when adding 1 to nil)
